### PR TITLE
fix: v1.0.1 refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ESS-DIVE Reporting Format for Comma-separated Values (CSV) File Structure v1.0.0
+# ESS-DIVE Reporting Format for Comma-separated Values (CSV) File Structure v1.0.1
 
 Tabular data in the form of rows and columns should be archived in its simplest form. Submit these data following the ESS-DIVE Reporting Format for Comma-separated Values (CSV) File Structure. The CSV reporting format is more likely accessible by future systems over a proprietary format and is preferred because this format is easier to exchange between different programs increasing the interoperability of the data file. Defining the reporting format and structure of the CSV file and some field content increases the machine-readability of the data file for extracting, compiling, and comparing the data across files and systems. 
  
@@ -15,12 +15,12 @@ Other documents:
 - [Quick Guide to the Elements](csv_quick_guide.md)
 
 ---
-## Updates in v1.0.0  
-This is the initial release of the reporting format for CSV file structure
+## Updates in v1.0.1 
+In March 2025, a patch version of the CSV File Formatting Guidelines reporting format was made to improve the overall experience with the associated reporting format documentation. Additionally, the standard reporting format keyword and standard term were added to the csv_instructions.md file.
 
 ## How to contribute
 
-This CSV data reporting format is evolving and growing to meet the needs of the community. Feedback and new contributions are welcome towards the development of new versions. If you would like to suggest a change or report a problem, please submit a GitHub issue using one of the templates we provide.
+This CSV data reporting format is evolving and growing to meet the needs of researchers. Feedback and new contributions are welcome towards the development of new versions. If you would like to suggest a change or report a problem, please submit a GitHub issue using one of the templates we provide.
 
 If you have any questions about this reporting format, you can also directly email ESS-DIVE support at ess-dive-support@lbl.gov.
 
@@ -46,7 +46,7 @@ McNelis, J., Crow, M., and Devarakonda, R., ESS-DIVE File Level Metadata Extract
 
 ## References  
 
-This recommended CSV file reporting format is based on a combination of existing guidelines and recommendations including some found within the Earth Science Community with additional input from the Environmental Systems Science (ESS) Community. While there are many variants, RFC 4180 (Shafranovich 2005) is commonly treated as the standard. The BADC-CSV format (Pepler & Parton 2009) is a variant of the CSV file format created by the British Atmospheric Data Centre for atmospheric observation data. Similarly, the ASCII format (Evans et al. 2016) can be considered a variant of a CSV file when the content is delimited with a comma. The ASCII format follows RFC 4180, is intuitive, and was created for Earth science data. CSV files are compatible with Unicode and ASCII character sets; however, the EDI recommends ASCII text (256 characters) delimited by tab or comma (EDI 2019).   
+This recommended CSV file reporting format is based on a combination of existing guidelines and recommendations including some found within Earth Science research with additional input from the Environmental Systems Science (ESS) researchers. While there are many variants, RFC 4180 (Shafranovich 2005) is commonly treated as the standard. The BADC-CSV format (Pepler & Parton 2009) is a variant of the CSV file format created by the British Atmospheric Data Centre for atmospheric observation data. Similarly, the ASCII format (Evans et al. 2016) can be considered a variant of a CSV file when the content is delimited with a comma. The ASCII format follows RFC 4180, is intuitive, and was created for Earth science data. CSV files are compatible with Unicode and ASCII character sets; however, the EDI recommends ASCII text (256 characters) delimited by tab or comma (EDI 2019).   
 
 EDI (Environmental Data Initiative). 2019. Five phases of data publishing - Phase 2: Format and QC data tables. https://environmentaldatainitiative.org/five-phases-of-data-publishing/phase-2/
 

--- a/csv_instructions.md
+++ b/csv_instructions.md
@@ -6,8 +6,8 @@
   a. [Detailed Guide to the Elements](csv_detailed_guide.md)  
   b. [Quick guide to the Elements](csv_quick_guide.md)
 2. If the data are initially saved in a different program (e.g. Excel), comply with the reporting format, convert the file to CSV, and resolve data inconsistencies and/or formatting problems.
-3. Submit a companion CSV data dictionary following the [CSV_dd_instructions](https://github.com/ess-dive-community/essdive-file-level-metadata/tree/master/CSV_dd).
-
+3. Submit a companion CSV data dictionary following the [CSV_dd_instructions](https://github.com/ess-dive-workspace/essdive-file-level-metadata/tree/main/CSV_dd).
+4. Within the FLMD file, the [standard](https://github.com/ess-dive-workspace/essdive-file-level-metadata/blob/main/flmd_quick_guide.md#standard) for each CSV guidelines reporting format related file should be **ESS-DIVE CSV v1**. If submitting your dataset to ESS-DIVE, include the keyword **ESS-DIVE CSV File Formatting Guidelines Reporting Format** in the package-level metadata.
 
 ## Notes
 


### PR DESCRIPTION
In March 2025, a patch version of the CSV File Formatting Guidelines reporting format was made to improve the overall experience with the associated reporting format documentation. Additionally, the standard reporting format keyword and standard term were added to the csv_instructions.md file. The following files were updated:

- README.md
- csv_instructions.md